### PR TITLE
Update changelog with new sites and channels

### DIFF
--- a/更新日志.md
+++ b/更新日志.md
@@ -1,4 +1,13 @@
 # 更新日志
+## 2026/02/02
+- ➕添加新站点：`ACGBUSTER藏宝库`、`ACG愿望`、`维咔VikACG`、`ACG嘤嘤怪`、`ACGKnow`、`GGS Visual Novel`、`唯のVN档案馆`、`わふわふ`
+- ➖英灵殿新增：`忧郁的loli`、`GalGame藏经阁`、`ACG资源网`、`ACG异世界`、`落樱之时`、`yuanmeng`、`宅方社`、`好GAL`、`wobbay`、`Puppet Studio`、`gal研究部`、`GALXP`
+- 🌟Ciallo～(∠・ω< )⌒☆
+
+## 2026/02/01
+- ➕添加新Telegram频道：`夏轩阁`
+- ➖英灵殿新增：`夏轩阁`、`樱刻春影`、`西琳次元`、`莫邪ACG`
+- 🌟Ciallo～(∠・ω< )⌒☆
 
 ## 2026/01/22
 - ➕添加新站点：`MikuGame`


### PR DESCRIPTION
## 2026/02/02
- ➕添加新站点：`ACGBUSTER藏宝库`、`ACG愿望`、`维咔VikACG`、`ACG嘤嘤怪`、`ACGKnow`、`GGS Visual Novel`、`唯のVN档案馆`、`わふわふ`
- ➖英灵殿新增：`忧郁的loli`、`GalGame藏经阁`、`ACG资源网`、`ACG异世界`、`落樱之时`、`yuanmeng`、`宅方社`、`好GAL`、`wobbay`、`Puppet Studio`、`gal研究部`、`GALXP`
- 🌟Ciallo～(∠・ω< )⌒☆

## 2026/02/01
- ➕添加新Telegram频道：`夏轩阁`
- ➖英灵殿新增：`夏轩阁`、`樱刻春影`、`西琳次元`、`莫邪ACG`
- 🌟Ciallo～(∠・ω< )⌒☆