### PR TITLE
docs: 收录 v2dao 资源分享站

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 | 真红小站              | https://shinnku.com/                   | [GitHub](https://github.com/shinnku-nikaidou/upset-gal-web)                                     | -                      |
 | 梓澪の妙妙屋          | http://zi0.cc/                         | -                                                                                               | -                      |
 | 紫缘社                | https://galzy.moe/                     | -                                                                                               | -                      |
+| v2dao 资源分享站      | https://www.v2dao.com/                 | [v2dao.online](https://v2dao.online/) \| [v2dao.link](https://v2dao.link/)                      | -                      |
 
 ### Telegram频道
 | **站点名称**         | **链接**                        |


### PR DESCRIPTION
在「主要站点」列表新增 **v2dao 资源分享站**（https://www.v2dao.com/）。

- 性质：galgame / ACG 资源分享站，设有「免费」专区（`/contents?isFree=true`），并提供网盘直链、漫画、小说等。
- 附常用镜像域名：v2dao.online、v2dao.link。
- 若实际访问存在登录门槛，可据此把备注栏标为「需登录」，由维护者定夺。

感谢维护，祝项目越来越好~