### PR TITLE
收录 SakuGAL；申请移除绮梦ACG（原站长）

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | MikuGame              | https://mikugame.icu/                  | -                                                                                               | -                      |
 | NekoGAL               | https://www.nekogal.com/               | -                                                                                               | 需登录 \| 需回复       |
 | Nysource              | https://nysoure.com/                   | [GitHub](https://github.com/KUN1007/kun-touchgal-next)                                          | -                      |
-| SakuGAL | https://sakugal.com/ | - | 免费下载 \| 无需注册 |
+| SakuGAL | https://sakugal.com/ | - | 需回复 | 无需注册 |
 | Sharotto              | https://www.sharotto.com/              | -                                                                                               | 需登录 \| 每日限量下载 |
 | Shionlib              | https://shionlib.com                   | [GitHub](https://github.com/Ringyuki/shionlib-frontend)                                         | -                      |
 | Singureo              | https://www.singureo.com/              | -                                                                                               | -                      |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | MikuGame              | https://mikugame.icu/                  | -                                                                                               | -                      |
 | NekoGAL               | https://www.nekogal.com/               | -                                                                                               | 需登录 \| 需回复       |
 | Nysource              | https://nysoure.com/                   | [GitHub](https://github.com/KUN1007/kun-touchgal-next)                                          | -                      |
-| SakuGAL | https://sakugal.com/ | - | 需回复 | 无需注册 |
+| SakuGAL | https://sakugal.com/ | - | 需回复 |
 | Sharotto              | https://www.sharotto.com/              | -                                                                                               | 需登录 \| 每日限量下载 |
 | Shionlib              | https://shionlib.com                   | [GitHub](https://github.com/Ringyuki/shionlib-frontend)                                         | -                      |
 | Singureo              | https://www.singureo.com/              | -                                                                                               | -                      |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | MikuGame              | https://mikugame.icu/                  | -                                                                                               | -                      |
 | NekoGAL               | https://www.nekogal.com/               | -                                                                                               | 需登录 \| 需回复       |
 | Nysource              | https://nysoure.com/                   | [GitHub](https://github.com/KUN1007/kun-touchgal-next)                                          | -                      |
+| SakuGAL | https://sakugal.com/ | - | 免费下载 \| 无需注册 |
 | Sharotto              | https://www.sharotto.com/              | -                                                                                               | 需登录 \| 每日限量下载 |
 | Shionlib              | https://shionlib.com                   | [GitHub](https://github.com/Ringyuki/shionlib-frontend)                                         | -                      |
 | Singureo              | https://www.singureo.com/              | -                                                                                               | -                      |
@@ -63,7 +64,6 @@
 | 猫猫网盘              | https://catcat.cloud/                  | [GitHub](https://github.com/Yuri-NagaSaki)                                                      | -                      |
 | 喵源领域              | https://www.nyantaku.com/              | [地址发布页](https://www.acgn.im/) \| [网盘页面](https://www.nullcloud.top/)                    | 需登录                 |
 | 魔皇地狱              | https://pan.mhdy.net/                  | [地址发布页](https://www.mohuangdiyu.com/)                                                      | -                      |
-| 绮梦ACG               | https://game.acgs.one/                 | -                                                                                               | 需回复                 |
 | 青桔网                | https://x.qingju.org/zh-CN             | [GitHub](https://github.com/qingjuacg/qingju/)                                                  | -                      |
 | 四叶草与雏菊的GAL小站 | https://g.杏铃.top                     | -                                                                                               | 需登录 \| 需回复       |
 | 小鳥遊暁の会员制餐厅  | https://t-satoru.top/                  | -                                                                                               | 仅移动端资源           |


### PR DESCRIPTION
## 新增收录：SakuGAL

| 项目 | 内容 |
| -- | -- |
| 站点名称 | SakuGAL |
| 链接 | https://sakugal.com/ |
| LOGO | https://sakugal.com/favicon.ico |
| 描述 | 免费 Galgame 资源分享——珍惜每一段恋之故事 |
| 关键词 | Gal, Galgame, 免费资源下载 |

**收录理由**：全部资源免登录、无积分/等级门槛即可直接下载，符合项目说明第 1 条「无门槛免费下载」的要求；3400+ 汉化作品，B2 + Cloudflare 直链下载，更新持续。

## 移除：绮梦ACG（https://game.acgs.one/）

提交者（本 PR 作者）即 **绮梦ACG 原站长**。该站现已失去原域名与服务器的控制权，原班人马已解散：

- 原域名当前会跳转到不相干的网页；
- 站点内容不再更新，且急于接入广告变现，已违背原站的初衷。

按项目说明中「站长可联系删除」的约定，申请将绮梦ACG 从列表中移除。

如有任何疑问欢迎在本 PR 下留言。